### PR TITLE
Rename fused float, double type to float_ft rather than decimal_t

### DIFF
--- a/sparse_dot_topn/sparse_dot_topn.pyx
+++ b/sparse_dot_topn/sparse_dot_topn.pyx
@@ -29,7 +29,7 @@ import numpy as np
 np.import_array()
 
 
-ctypedef fused  decimal_t:
+ctypedef fused  float_ft:
 	cython.float
 	cython.double
 
@@ -85,11 +85,11 @@ cdef extern from "sparse_dot_topn_source.h":
 		T lower_bound
 	) except +;
 
-cpdef ArrayWrapper_template(vector[decimal_t] vCx):
+cpdef ArrayWrapper_template(vector[float_ft] vCx):
 	# raise Exception("In sparse_dot_topn.pyx")
-	if decimal_t is float:
+	if float_ft is float:
 		return ArrayWrapper_float(vCx)
-	elif decimal_t is double:
+	elif float_ft is double:
 		return ArrayWrapper_double(vCx)
 	else:
 		raise Exception("Type not supported")
@@ -99,15 +99,15 @@ cpdef sparse_dot_topn(
 	int n_col,
 	np.ndarray[int, ndim=1] a_indptr,
 	np.ndarray[int, ndim=1] a_indices,
-	np.ndarray[decimal_t, ndim=1] a_data,
+	np.ndarray[float_ft, ndim=1] a_data,
 	np.ndarray[int, ndim=1] b_indptr,
 	np.ndarray[int, ndim=1] b_indices,
-	np.ndarray[decimal_t, ndim=1] b_data,
+	np.ndarray[float_ft, ndim=1] b_data,
 	int ntop,
-	decimal_t lower_bound,
+	float_ft lower_bound,
 	np.ndarray[int, ndim=1] c_indptr,
 	np.ndarray[int, ndim=1] c_indices,
-	np.ndarray[decimal_t, ndim=1] c_data
+	np.ndarray[float_ft, ndim=1] c_data
 ):
 	"""
 	Cython glue function to call sparse_dot_topn C++ implementation
@@ -133,13 +133,13 @@ cpdef sparse_dot_topn(
 
 	cdef int* Ap = &a_indptr[0]
 	cdef int* Aj = &a_indices[0]
-	cdef decimal_t* Ax = &a_data[0]
+	cdef float_ft* Ax = &a_data[0]
 	cdef int* Bp = &b_indptr[0]
 	cdef int* Bj = &b_indices[0]
-	cdef decimal_t* Bx = &b_data[0]
+	cdef float_ft* Bx = &b_data[0]
 	cdef int* Cp = &c_indptr[0]
 	cdef int* Cj = &c_indices[0]
-	cdef decimal_t* Cx = &c_data[0]
+	cdef float_ft* Cx = &c_data[0]
 
 	sparse_dot_topn_source(
 		n_row, n_col, Ap, Aj, Ax, Bp, Bj, Bx, ntop, lower_bound, Cp, Cj, Cx
@@ -151,15 +151,15 @@ cpdef sparse_dot_topn_extd(
 	int n_col,
 	np.ndarray[int, ndim=1] a_indptr,
 	np.ndarray[int, ndim=1] a_indices,
-	np.ndarray[decimal_t, ndim=1] a_data,
+	np.ndarray[float_ft, ndim=1] a_data,
 	np.ndarray[int, ndim=1] b_indptr,
 	np.ndarray[int, ndim=1] b_indices,
-	np.ndarray[decimal_t, ndim=1] b_data,
+	np.ndarray[float_ft, ndim=1] b_data,
 	int ntop,
-	decimal_t lower_bound,
+	float_ft lower_bound,
 	np.ndarray[int, ndim=1] c_indptr,
 	np.ndarray[int, ndim=1] c_indices,
-	np.ndarray[decimal_t, ndim=1] c_data,
+	np.ndarray[float_ft, ndim=1] c_data,
 	np.ndarray[int, ndim=1] nminmax
 ):
 	"""
@@ -201,19 +201,19 @@ cpdef sparse_dot_topn_extd(
 
 	cdef int* Ap = &a_indptr[0]
 	cdef int* Aj = &a_indices[0]
-	cdef decimal_t* Ax = &a_data[0]
+	cdef float_ft* Ax = &a_data[0]
 	cdef int* Bp = &b_indptr[0]
 	cdef int* Bj = &b_indices[0]
-	cdef decimal_t* Bx = &b_data[0]
+	cdef float_ft* Bx = &b_data[0]
 	cdef int* Cp = &c_indptr[0]
 	cdef int* Cj = &c_indices[0]
-	cdef decimal_t* Cx = &c_data[0]
+	cdef float_ft* Cx = &c_data[0]
 	cdef int* n_minmax = &nminmax[0]
 	
 	cdef nnz_max = len(c_indices)
 	
 	cdef vector[int] vCj;
-	cdef vector[decimal_t] vCx;
+	cdef vector[float_ft] vCx;
 
 	cdef int nnz_max_is_too_small = sparse_dot_topn_extd_source(
 		n_row, n_col, Ap, Aj, Ax, Bp, Bj, Bx, ntop, lower_bound, Cp, Cj, Cx, &vCj, &vCx, nnz_max, n_minmax
@@ -237,12 +237,12 @@ cpdef sparse_dot_only_nnz(
 	int n_col,
 	np.ndarray[int, ndim=1] a_indptr,
 	np.ndarray[int, ndim=1] a_indices,
-	np.ndarray[decimal_t, ndim=1] a_data,
+	np.ndarray[float_ft, ndim=1] a_data,
 	np.ndarray[int, ndim=1] b_indptr,
 	np.ndarray[int, ndim=1] b_indices,
-	np.ndarray[decimal_t, ndim=1] b_data,
+	np.ndarray[float_ft, ndim=1] b_data,
 	int ntop,
-	decimal_t lower_bound
+	float_ft lower_bound
 ):
 	"""
 	Cython glue function to call sparse_dot_nnz_only C++ implementation
@@ -268,10 +268,10 @@ cpdef sparse_dot_only_nnz(
 
 	cdef int* Ap = &a_indptr[0]
 	cdef int* Aj = &a_indices[0]
-	cdef decimal_t* Ax = &a_data[0]
+	cdef float_ft* Ax = &a_data[0]
 	cdef int* Bp = &b_indptr[0]
 	cdef int* Bj = &b_indices[0]
-	cdef decimal_t* Bx = &b_data[0]
+	cdef float_ft* Bx = &b_data[0]
 
 	return sparse_dot_only_nnz_source(
 		n_row, n_col, Ap, Aj, Ax, Bp, Bj, Bx, ntop, lower_bound

--- a/sparse_dot_topn/sparse_dot_topn_threaded.pyx
+++ b/sparse_dot_topn/sparse_dot_topn_threaded.pyx
@@ -30,7 +30,7 @@ import numpy as np
 np.import_array()
 
 
-ctypedef fused  decimal_t:
+ctypedef fused  float_ft:
 	cython.float
 	cython.double
 
@@ -94,38 +94,38 @@ cpdef sparse_dot_topn_threaded(
 	int n_col,
 	np.ndarray[int, ndim=1] a_indptr,
 	np.ndarray[int, ndim=1] a_indices,
-	np.ndarray[decimal_t, ndim=1] a_data,
+	np.ndarray[float_ft, ndim=1] a_data,
 	np.ndarray[int, ndim=1] b_indptr,
 	np.ndarray[int, ndim=1] b_indices,
-	np.ndarray[decimal_t, ndim=1] b_data,
+	np.ndarray[float_ft, ndim=1] b_data,
 	int ntop,
-	decimal_t lower_bound,
+	float_ft lower_bound,
 	np.ndarray[int, ndim=1] c_indptr,
 	np.ndarray[int, ndim=1] c_indices,
-	np.ndarray[decimal_t, ndim=1] c_data,
+	np.ndarray[float_ft, ndim=1] c_data,
 	int n_jobs
 ):
 
 	cdef int* Ap = &a_indptr[0]
 	cdef int* Aj = &a_indices[0]
-	cdef decimal_t* Ax = &a_data[0]
+	cdef float_ft* Ax = &a_data[0]
 	cdef int* Bp = &b_indptr[0]
 	cdef int* Bj = &b_indices[0]
-	cdef decimal_t* Bx = &b_data[0]
+	cdef float_ft* Bx = &b_data[0]
 	cdef int* Cp = &c_indptr[0]
 	cdef int* Cj = &c_indices[0]
-	cdef decimal_t* Cx = &c_data[0]
+	cdef float_ft* Cx = &c_data[0]
 
 	sparse_dot_topn_parallel(
 		n_row, n_col, Ap, Aj, Ax, Bp, Bj, Bx, ntop, lower_bound, Cp, Cj, Cx, n_jobs
 	)
 	return
 
-cpdef ArrayWrapper_template(vector[decimal_t] vCx):
+cpdef ArrayWrapper_template(vector[float_ft] vCx):
 	# raise Exception("In sparse_dot_topn_threaded.pyx")
-	if decimal_t is float:
+	if float_ft is float:
 		return ArrayWrapper_float(vCx)
-	elif decimal_t is double:
+	elif float_ft is double:
 		return ArrayWrapper_double(vCx)
 	else:
 		raise Exception("Type not supported")
@@ -135,34 +135,34 @@ cpdef sparse_dot_topn_extd_threaded(
 	int n_col,
 	np.ndarray[int, ndim=1] a_indptr,
 	np.ndarray[int, ndim=1] a_indices,
-	np.ndarray[decimal_t, ndim=1] a_data,
+	np.ndarray[float_ft, ndim=1] a_data,
 	np.ndarray[int, ndim=1] b_indptr,
 	np.ndarray[int, ndim=1] b_indices,
-	np.ndarray[decimal_t, ndim=1] b_data,
+	np.ndarray[float_ft, ndim=1] b_data,
 	int ntop,
-	decimal_t lower_bound,
+	float_ft lower_bound,
 	np.ndarray[int, ndim=1] c_indptr,
 	np.ndarray[int, ndim=1] c_indices,
-	np.ndarray[decimal_t, ndim=1] c_data,
+	np.ndarray[float_ft, ndim=1] c_data,
 	np.ndarray[int, ndim=1] nminmax,
 	int n_jobs
 ):
 
 	cdef int* Ap = &a_indptr[0]
 	cdef int* Aj = &a_indices[0]
-	cdef decimal_t* Ax = &a_data[0]
+	cdef float_ft* Ax = &a_data[0]
 	cdef int* Bp = &b_indptr[0]
 	cdef int* Bj = &b_indices[0]
-	cdef decimal_t* Bx = &b_data[0]
+	cdef float_ft* Bx = &b_data[0]
 	cdef int* Cp = &c_indptr[0]
 	cdef int* Cj = &c_indices[0]
-	cdef decimal_t* Cx = &c_data[0]
+	cdef float_ft* Cx = &c_data[0]
 	cdef int* n_minmax = &nminmax[0]
 	
 	cdef nnz_max = len(c_indices)
 	
 	cdef vector[int] vCj;
-	cdef vector[decimal_t] vCx;
+	cdef vector[float_ft] vCx;
 
 	cdef int nnz_max_is_too_small = sparse_dot_topn_extd_parallel(
 		n_row, n_col, Ap, Aj, Ax, Bp, Bj, Bx, ntop, lower_bound, Cp, Cj, Cx, &vCj, &vCx, nnz_max, n_minmax, n_jobs
@@ -186,21 +186,21 @@ cpdef sparse_dot_only_nnz_threaded(
 	int n_col,
 	np.ndarray[int, ndim=1] a_indptr,
 	np.ndarray[int, ndim=1] a_indices,
-	np.ndarray[decimal_t, ndim=1] a_data,
+	np.ndarray[float_ft, ndim=1] a_data,
 	np.ndarray[int, ndim=1] b_indptr,
 	np.ndarray[int, ndim=1] b_indices,
-	np.ndarray[decimal_t, ndim=1] b_data,
+	np.ndarray[float_ft, ndim=1] b_data,
 	int ntop,
-	decimal_t lower_bound,
+	float_ft lower_bound,
 	int n_jobs
 ):
 
 	cdef int* Ap = &a_indptr[0]
 	cdef int* Aj = &a_indices[0]
-	cdef decimal_t* Ax = &a_data[0]
+	cdef float_ft* Ax = &a_data[0]
 	cdef int* Bp = &b_indptr[0]
 	cdef int* Bj = &b_indices[0]
-	cdef decimal_t* Bx = &b_data[0]
+	cdef float_ft* Bx = &b_data[0]
 
 	return sparse_dot_only_nnz_parallel(
 		n_row, n_col, Ap, Aj, Ax, Bp, Bj, Bx, ntop, lower_bound, n_jobs


### PR DESCRIPTION
Change to the naming of the fused typed introduced in #55 . `decimal_t` is a bit misleading name as decimal types and float types are not the same.