### PR TITLE
Fix numpy ABI compatible and Use CIBuildWheel and github action to build python wheels automatically

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,4 +32,4 @@ jobs:
       run: |
         pip install pytest
         pip install pandas
-        pytest -ra --capture=no --showlocals tests
+        pytest -ra --capture=no --showlocals

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+      - test/**
+      - release/**
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - master
-      - test/**
-      - release/**
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9]
         os: [ubuntu-latest, windows-latest]
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,4 +32,4 @@ jobs:
       run: |
         pip install pytest
         pip install pandas
-        pytest -ra --capture=no --showlocals
+        pytest -ra --capture=no --showlocals tests

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,0 +1,69 @@
+name: Build Python wheels and publish
+
+# Controls when the workflow will run
+on:
+  # run pipeline on push event of main or release branch
+  push:
+    branches:
+      # TODO: remove `test/` later
+      - 'test/**'
+      - 'release/**'
+  # run pipeline on pull request
+  pull_request:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build-and-test-python:
+    strategy:
+      matrix:
+        platform: [ linux, macos, windows ]
+ 
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@2.7.0
+
+      - name: Keep wheel files
+        uses: actions/upload-artifact@v3
+        with:
+          name: wheelhouse
+          path: ./wheelhouse/*.whl
+
+
+  publish-wheels:
+    needs: build-and-test-python
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+          architecture: x64
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: wheelhouse
+          path: wheelhouse
+
+      - name: List assets
+        run: |
+          ls ./wheelhouse/*.whl -al
+
+      - name: Upload wheels to test PyPI
+        if: (github.event_name == 'push') || (github.event_name == 'workflow_dispatch')
+        run: |
+          pip install twine
+          echo "Publish to Test PyPI..."
+          twine upload --verbose --repository testpypi wheelhouse/*
+        env:
+          TWINE_USERNAME: ${{ secrets.PYPI_TEST_USER }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_TEST_PASS }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -17,7 +17,7 @@ jobs:
   build-and-test-python:
     strategy:
       matrix:
-        platform: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ubuntu-latest, macos-latest, windows-latest]
  
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -33,7 +33,7 @@ jobs:
 
     env:
       CIBW_ENVIRONMENT_WINDOWS: SETUPTOOLS_USE_DISTUTILS=stdlib
-      CIBW_SKIP: pp*-*_x86_64
+      CIBW_SKIP: pp3*
       CIBW_ARCHS: ${{ matrix.archs }}
       CIBW_TEST_REQUIRES: pytest pandas
       CIBW_TEST_COMMAND: >

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -36,7 +36,8 @@ jobs:
       CIBW_SKIP: pp37-macosx_x86_64
       CIBW_ARCHS: ${{ matrix.archs }}
       CIBW_TEST_REQUIRES: pytest pandas
-      CIBW_TEST_COMMAND: pytest -ra --capture=no --showlocals tests
+      CIBW_TEST_COMMAND: >
+        pytest -ra --capture=no --showlocals {package}/tests
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@2.7.0
+        uses: pypa/cibuildwheel@2.6.1
 
       - name: Keep wheel files
         uses: actions/upload-artifact@v3

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -22,12 +22,15 @@ jobs:
           - platform: linux
             os: ubuntu-latest
             archs: "x86_64 aarch64"
+            test_cmd: python -m pytest -ra --capture=no --showlocals {package}/tests
           - platform: macos
             os: macos-latest
             archs: "x86_64 arm64"
+            test_cmd: pytest -ra --capture=no --showlocals {package}/tests
           - platform: windows
             os: windows-latest
             archs: AMD64
+            test_cmd: pytest -ra --capture=no --showlocals {package}/tests
 
     runs-on: ${{ matrix.os }}
 
@@ -36,8 +39,7 @@ jobs:
       CIBW_SKIP: pp3*
       CIBW_ARCHS: ${{ matrix.archs }}
       CIBW_TEST_REQUIRES: pytest pandas
-      CIBW_TEST_COMMAND: >
-        python -m pytest -ra --capture=no --showlocals {package}/tests
+      CIBW_TEST_COMMAND: ${{ matrix.test_cmd }}
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -23,6 +23,7 @@ jobs:
 
     env:
       CIBW_ENVIRONMENT_WINDOWS: SETUPTOOLS_USE_DISTUTILS=stdlib
+      CIBW_SKIP: pp37-macosx_x86_64
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -36,7 +36,7 @@ jobs:
       CIBW_SKIP: pp37-macosx_x86_64
       CIBW_ARCHS: ${{ matrix.archs }}
       CIBW_TEST_REQUIRES: pytest pandas
-      CIBW_TEST_COMMAND: pytest -ra --capture=no --showlocals
+      CIBW_TEST_COMMAND: pytest -ra --capture=no --showlocals tests
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -21,6 +21,9 @@ jobs:
  
     runs-on: ${{ matrix.os }}
 
+    env:
+      CIBW_ENVIRONMENT_WINDOWS: SETUPTOOLS_USE_DISTUTILS=stdlib
+
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -37,7 +37,7 @@ jobs:
       CIBW_ARCHS: ${{ matrix.archs }}
       CIBW_TEST_REQUIRES: pytest pandas
       CIBW_TEST_COMMAND: >
-        pytest -ra --capture=no --showlocals {package}/tests
+        python -m pytest -ra --capture=no --showlocals {package}/tests
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -17,7 +17,7 @@ jobs:
   build-and-test-python:
     strategy:
       matrix:
-        os: [linux, macos, windows]
+        platform: [linux, macos, windows]
         include:
           - platform: linux
             os: ubuntu-latest
@@ -25,25 +25,21 @@ jobs:
             # ` standard_init_linux.go:228: exec user process caused: exec format error`
             # and we don't know how to fix it
             archs: "x86_64" 
-            test_cmd: python -m pytest -ra --capture=no --showlocals {package}/tests
           - platform: macos
             os: macos-latest
             archs: "x86_64 arm64"
-            test_cmd: pytest -ra --capture=no --showlocals {package}/tests
           - platform: windows
             os: windows-latest
             archs: AMD64
-            test_cmd: pytest -ra --capture=no --showlocals {package}/tests
 
     runs-on: ${{ matrix.os }}
 
     env:
       CIBW_ENVIRONMENT_WINDOWS: SETUPTOOLS_USE_DISTUTILS=stdlib
-      CIBW_SKIP: pp3*
+      CIBW_SKIP: "pp3* *-musllinux_*"
       CIBW_ARCHS: ${{ matrix.archs }}
-      CIBW_BEFORE_TEST_LINUX: sudo apt-get install gfortran libopenblas-dev liblapack-dev      
       CIBW_TEST_REQUIRES: pytest pandas
-      CIBW_TEST_COMMAND: ${{ matrix.test_cmd }}
+      CIBW_TEST_COMMAND: pytest -ra --capture=no --showlocals {package}/tests
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -24,6 +24,8 @@ jobs:
     env:
       CIBW_ENVIRONMENT_WINDOWS: SETUPTOOLS_USE_DISTUTILS=stdlib
       CIBW_SKIP: pp37-macosx_x86_64
+      CIBW_TEST_REQUIRES: pytest pandas
+      CIBW_TEST_COMMAND: pytest -ra --capture=no --showlocals
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -33,7 +33,7 @@ jobs:
 
     env:
       CIBW_ENVIRONMENT_WINDOWS: SETUPTOOLS_USE_DISTUTILS=stdlib
-      CIBW_SKIP: pp37-macosx_x86_64
+      CIBW_SKIP: pp37-*_x86_64
       CIBW_ARCHS: ${{ matrix.archs }}
       CIBW_TEST_REQUIRES: pytest pandas
       CIBW_TEST_COMMAND: >

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -17,7 +17,7 @@ jobs:
   build-and-test-python:
     strategy:
       matrix:
-        platform: [ linux, macos, windows ]
+        platform: [ ubuntu-latest, macos-latest, windows-latest ]
  
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -33,7 +33,7 @@ jobs:
 
     env:
       CIBW_ENVIRONMENT_WINDOWS: SETUPTOOLS_USE_DISTUTILS=stdlib
-      CIBW_SKIP: pp37-*_x86_64
+      CIBW_SKIP: pp*-*_x86_64
       CIBW_ARCHS: ${{ matrix.archs }}
       CIBW_TEST_REQUIRES: pytest pandas
       CIBW_TEST_COMMAND: >

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -5,7 +5,6 @@ on:
   # run pipeline on push event of main or release branch
   push:
     branches:
-      # TODO: remove `test/` later
       - 'test/**'
       - 'release/**'
   # run pipeline on pull request
@@ -87,3 +86,13 @@ jobs:
         env:
           TWINE_USERNAME: ${{ secrets.PYPI_TEST_USER }}
           TWINE_PASSWORD: ${{ secrets.PYPI_TEST_PASS }}
+
+      - name: Upload wheels to official PyPI
+        if: contains(github.ref, 'release') && ((github.event_name == 'push') || (github.event_name == 'workflow_dispatch'))
+        run: |
+          pip install twine
+          echo "Publish to PyPI..."
+          twine upload --verbose wheelhouse/*
+        env:
+          TWINE_USERNAME: ${{ secrets.PYPI_USER }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASS }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -21,7 +21,10 @@ jobs:
         include:
           - platform: linux
             os: ubuntu-latest
-            archs: "x86_64 aarch64"
+            # Here we skip aarch64, since we got error
+            # ` standard_init_linux.go:228: exec user process caused: exec format error`
+            # and we don't know how to fix it
+            archs: "x86_64" 
             test_cmd: python -m pytest -ra --capture=no --showlocals {package}/tests
           - platform: macos
             os: macos-latest

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -17,13 +17,24 @@ jobs:
   build-and-test-python:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
- 
+        os: [linux, macos, windows]
+        include:
+          - platform: linux
+            os: ubuntu-latest
+            archs: "x86_64 aarch64"
+          - platform: macos
+            os: macos-latest
+            archs: "x86_64 arm64"
+          - platform: windows
+            os: windows-latest
+            archs: AMD64
+
     runs-on: ${{ matrix.os }}
 
     env:
       CIBW_ENVIRONMENT_WINDOWS: SETUPTOOLS_USE_DISTUTILS=stdlib
       CIBW_SKIP: pp37-macosx_x86_64
+      CIBW_ARCHS: ${{ matrix.archs }}
       CIBW_TEST_REQUIRES: pytest pandas
       CIBW_TEST_COMMAND: pytest -ra --capture=no --showlocals
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -41,6 +41,7 @@ jobs:
       CIBW_ENVIRONMENT_WINDOWS: SETUPTOOLS_USE_DISTUTILS=stdlib
       CIBW_SKIP: pp3*
       CIBW_ARCHS: ${{ matrix.archs }}
+      CIBW_BEFORE_TEST_LINUX: sudo apt-get install gfortran libopenblas-dev liblapack-dev      
       CIBW_TEST_REQUIRES: pytest pandas
       CIBW_TEST_COMMAND: ${{ matrix.test_cmd }}
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ From version 0.3.2, we employ Github Actions to build wheels in different OS env
 5. Create a branch on top of the test branch.
 6. Modify the version number by remove the `rcx` surfix.
 7. Git push, then build and publish pipeline will be triggered automatically. New release will be uploaded to PyPI [https://pypi.org/project/sparse-dot-topn](https://pypi.org/project/sparse-dot-topn/)
+8. Merge the release branch back to master
 
 
 

--- a/README.md
+++ b/README.md
@@ -66,9 +66,16 @@ pip install sparse_dot_topn-*.tar.gz
 ```
 
 ## Release strategy
-From version 0.3.2, we employ Github Actions to build wheels in different OS environment and release automatically. Hopefully this will solve many issues related to installation.
+From version 0.3.2, we employ Github Actions to build wheels in different OS environment and release automatically. Hopefully this will solve many issues related to installation. The build and publish pipeline is configured in `./github/workflows/wheels.yml`. When a new release is neeeded, please follow these steps
 
-The build and publish pipeline is configured in `./github/workflows/wheels.yml`. When a new release is neeeded, please:
-1. Create a release branch with branch name `release/vx.x.x` from main branch.
-2. Update the version number in setup.py, and update changelog in CHANGES.md file.
-3. Git push, then build and publish pipeline will be triggered automatically.
+1. Create a test branch with branch name `test/x.x.x` from main branch.
+2. In `test/x.x.x` branch, update the version number such as `x.x.x.rcx`in setup.py, and update changelog in CHANGES.md file. 
+3. Git push `test/x.x.x` branch, then build and publish pipeline will be triggered automatically. New release will be uploaded in PyPI test [https://test.pypi.org/project/sparse-dot-topn/](https://test.pypi.org/project/sparse-dot-topn/).
+4. Please do a sanity check on PyPI test release.
+5. Create a branch on top of the test branch.
+6. Modify the version number by remove the `rcx` surfix.
+7. Git push, then build and publish pipeline will be triggered automatically. New release will be uploaded to PyPI [https://pypi.org/project/sparse-dot-topn](https://pypi.org/project/sparse-dot-topn/)
+
+
+
+

--- a/README.md
+++ b/README.md
@@ -69,6 +69,6 @@ pip install sparse_dot_topn-*.tar.gz
 From version 0.3.2, we employ Github Actions to build wheels in different OS environment and release automatically. Hopefully this will solve many issues related to installation.
 
 The build and publish pipeline is configured in `./github/workflows/wheels.yml`. When a new release is neeeded, please:
-1. Create a release branch with branch name `release/vx.x.x` from main branch
-2. Update the version number in setup.py
-3. Git push, then build and publish pipeline will be triggered automatically
+1. Create a release branch with branch name `release/vx.x.x` from main branch.
+2. Update the version number in setup.py, and update changelog in CHANGES.md file.
+3. Git push, then build and publish pipeline will be triggered automatically.

--- a/README.md
+++ b/README.md
@@ -64,3 +64,11 @@ python -m build
 cd dist/
 pip install sparse_dot_topn-*.tar.gz
 ```
+
+## Release strategy
+From version 0.3.2, we employ Github Actions to build wheels in different OS environment and release automatically. Hopefully this will solve many issues related to installation.
+
+The build and publish pipeline is configured in `./github/workflows/wheels.yml`. When a new release is neeeded, please:
+1. Create a release branch with branch name `release/vx.x.x` from main branch
+2. Update the version number in setup.py
+3. Git push, then build and publish pipeline will be triggered automatically

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ requires = [
     "setuptools>=42",
     "wheel",
     "cython",
-    "oldest-supported-numpy"
+    "oldest-supported-numpy",
+    "numpy==1.16.6; python_version=='3.7'"
 ]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,6 @@ requires = [
     "setuptools>=42",
     "wheel",
     "cython",
-    "oldest-supported-numpy",
-    "numpy==1.16.6; python_version=='3.7'"
+    "oldest-supported-numpy"
 ]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,8 @@
 [build-system]
 requires = [
     "setuptools>=42",
-    "wheel"
+    "wheel",
+    "cython",
+    "oldest-supported-numpy"
 ]
 build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy>=1.16.6
+numpy>=1.14.5
 setuptools>=45.2.0
 Cython>=0.29.15
 scipy>=1.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy>=1.14.5
+numpy>=1.16.6
 setuptools>=45.2.0
 Cython>=0.29.15
 scipy>=1.4.1

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ threaded_ext = Extension('sparse_dot_topn.sparse_dot_topn_threaded',
 
 setup(
     name='sparse_dot_topn',
-    version='0.3.2.rc2',
+    version='0.3.2.rc3',
     description='This package boosts a sparse matrix multiplication '\
                 'followed by selecting the top-n multiplication',
     keywords='cosine-similarity sparse-matrix scipy cython',

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ threaded_ext = Extension('sparse_dot_topn.sparse_dot_topn_threaded',
 
 setup(
     name='sparse_dot_topn',
-    version='0.3.2.rc4',
+    version='0.3.2',
     description='This package boosts a sparse matrix multiplication '\
                 'followed by selecting the top-n multiplication',
     keywords='cosine-similarity sparse-matrix scipy cython',

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ threaded_ext = Extension('sparse_dot_topn.sparse_dot_topn_threaded',
 
 setup(
     name='sparse_dot_topn',
-    version='0.3.1',
+    version='0.3.2.rc2',
     description='This package boosts a sparse matrix multiplication '\
                 'followed by selecting the top-n multiplication',
     keywords='cosine-similarity sparse-matrix scipy cython',
@@ -84,7 +84,6 @@ setup(
     install_requires=[
         # Setuptools 18.0 properly handles Cython extensions.
         'setuptools>=42',
-        'cython>=0.29.15',
         'numpy>=1.16.6', # select this version for Py2/3 compatible
         'scipy>=1.2.3'   # select this version for Py2/3 compatible
     ],

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ threaded_ext = Extension('sparse_dot_topn.sparse_dot_topn_threaded',
 
 setup(
     name='sparse_dot_topn',
-    version='0.3.2.rc3',
+    version='0.3.2.rc4',
     description='This package boosts a sparse matrix multiplication '\
                 'followed by selecting the top-n multiplication',
     keywords='cosine-similarity sparse-matrix scipy cython',

--- a/setup.py
+++ b/setup.py
@@ -78,13 +78,15 @@ setup(
         # Setuptools 18.0 properly handles Cython extensions.
         'setuptools>=42',
         'cython>=0.29.15',
-        'numpy>=1.16.6', # select this version for Py2/3 compatible
+        # select this version due to oldest_support_numpy https://github.com/scipy/oldest-supported-numpy/blob/main/setup.cfg#L54
+        'numpy>=1.14.5', 
         'scipy>=1.2.3'   # select this version for Py2/3 compatible
     ],
     install_requires=[
         # Setuptools 18.0 properly handles Cython extensions.
         'setuptools>=42',
-        'numpy>=1.16.6', # select this version for Py2/3 compatible
+        # select this version due to oldest_support_numpy https://github.com/scipy/oldest-supported-numpy/blob/main/setup.cfg#L54
+        'numpy>=1.14.5',
         'scipy>=1.2.3'   # select this version for Py2/3 compatible
     ],
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -74,17 +74,7 @@ setup(
     author='Zhe Sun',
     author_email='ymwdalex@gmail.com',
     license='Apache 2.0',
-    setup_requires=[
-        # Setuptools 18.0 properly handles Cython extensions.
-        'setuptools>=42',
-        'cython>=0.29.15',
-        # select this version due to oldest_support_numpy https://github.com/scipy/oldest-supported-numpy/blob/main/setup.cfg#L54
-        'numpy>=1.14.5', 
-        'scipy>=1.2.3'   # select this version for Py2/3 compatible
-    ],
     install_requires=[
-        # Setuptools 18.0 properly handles Cython extensions.
-        'setuptools>=42',
         # select this version due to oldest_support_numpy https://github.com/scipy/oldest-supported-numpy/blob/main/setup.cfg#L54
         'numpy>=1.14.5',
         'scipy>=1.2.3'   # select this version for Py2/3 compatible


### PR DESCRIPTION
1. improve setup.py and pyproject.toml files to fix numpy ABI compatible problem
2. add github actions to employ cibuildwheel to build python wheels automatically