### PR TITLE
Patch: fix cython to 0.29.36 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [build-system]
 requires = [
-    "setuptools>=42",
-    "wheel",
-    "cython",
-    "oldest-supported-numpy"
+  "setuptools>=42",
+  "wheel",
+  "cython>=0.29.15,<3.0.0",
+  "oldest-supported-numpy",
 ]
 build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 numpy>=1.14.5
 setuptools>=45.2.0
-Cython>=0.29.15
+Cython>=0.29.15,<3.0.0
 scipy>=1.4.1


### PR DESCRIPTION
In relation to issue #84 

Cython recently had a major release which is causing havoc amongst dependencies near and far. 

This PR fixes cython `0.29.36` to prevent `pip install` from trying and failing to pull cython 3.