### PR TITLE
Fix imports that fail under Cython 3.0 in language_level=3 mode

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
   "setuptools>=42",
   "wheel",
-  "cython>=0.29.15,<3.0.0",
+  "cython>=0.29.15",
   "oldest-supported-numpy",
 ]
 build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 numpy>=1.14.5
 setuptools>=45.2.0
-Cython>=0.29.15,<3.0.0
+Cython>=0.29.15
 scipy>=1.4.1

--- a/sparse_dot_topn/sparse_dot_topn.pyx
+++ b/sparse_dot_topn/sparse_dot_topn.pyx
@@ -20,7 +20,7 @@
 # distutils: language = c++
 
 from libcpp.vector cimport vector
-from array_wrappers cimport ArrayWrapper_int, ArrayWrapper_float, ArrayWrapper_double
+from sparse_dot_topn.array_wrappers cimport ArrayWrapper_int, ArrayWrapper_float, ArrayWrapper_double
 
 cimport cython
 cimport numpy as np

--- a/sparse_dot_topn/sparse_dot_topn_threaded.pyx
+++ b/sparse_dot_topn/sparse_dot_topn_threaded.pyx
@@ -20,7 +20,7 @@
 # distutils: language = c++
 
 from libcpp.vector cimport vector
-from array_wrappers cimport ArrayWrapper_int, ArrayWrapper_float, ArrayWrapper_double
+from sparse_dot_topn.array_wrappers cimport ArrayWrapper_int, ArrayWrapper_float, ArrayWrapper_double
 
 cimport cython
 cimport numpy as np


### PR DESCRIPTION
**Note**: I recognize that #85 has already been merged and released. I made the changes in this PR in an equivalent proposal for [sparse_dot_topn_for_blocks](https://github.com/ParticularMiner/sparse_dot_topn_for_blocks/pull/5), so I thought I'd make the same offer in this repository if the maintainers are interested in not having Cython pinned to < 3.0.0.

The release of Cython 3.0 on July 27, 2023 broke the build for this package by introducing breaking changes. This PR addresses those changes and fixes a few imports that no longer work with Cython 3.0. These changes are also backwards compatible for people who decide to build this package using older versions of Cython.

This addresses issue #84 in this repository, as well as a few issues found in other repos.
https://github.com/ParticularMiner/sparse_dot_topn_for_blocks/issues/3
https://github.com/Bergvca/string_grouper/issues/93

---

Also just because I was curious, if you really didn't want to change the imports and wanted everything to go back to the way it was without pinning the version, you can configure Cython to go back to the old behavior. You have to add Cython to the build-system requires in `pyproject.toml`, add `from Cython.Build import cythonize` to `setup.py`, and then change line 95 to `ext_modules=cythonize([array_wrappers_ext, original_ext, threaded_ext], language_level='2'),`.