### PR TITLE
FIX: Enforce sub-matrix shape to all-zero columns being dropped

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Release history:
 
+## v1.1.1
+
+### Internal
+
+- FIX: Prevent Scipy from dropping columns that are all zero for sub-matrices
+
 ## v1.1.0
 
 Add new function to select top-n from blocks of a sparse matrix matmul.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "sparse_dot_topn"
-version = "1.1.0"
+version = "1.1.1"
 description = "This package boosts a sparse matrix multiplication followed by selecting the top-n multiplication"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/sparse_dot_topn/api.py
+++ b/src/sparse_dot_topn/api.py
@@ -324,18 +324,15 @@ def zip_sp_matmul_topn(top_n: int, C_mats: list[csr_matrix]) -> csr_matrix:
         indptr.append(C.indptr)
         indices.append(C.indices)
 
+    ncols = np.asarray(ncols, int)
+    total_cols = ncols.sum()
     if not np.all(np.diff(_nrows) == 0):
         msg = "Each `C` in `C_mats` should have the same number of rows."
         raise ValueError(msg)
 
     return csr_matrix(
         _core.zip_sp_matmul_topn(
-            top_n=top_n,
-            Z_max_nnz=nrows * top_n,
-            nrows=nrows,
-            B_ncols=np.asarray(ncols, int),
-            data=data,
-            indptr=indptr,
-            indices=indices,
-        )
+            top_n=top_n, Z_max_nnz=nrows * top_n, nrows=nrows, B_ncols=ncols, data=data, indptr=indptr, indices=indices
+        ),
+        shape=(nrows, total_cols),
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,4 +4,4 @@ import pytest
 
 @pytest.fixture(scope="package")
 def rng():
-    return np.random.Generator(np.random.PCG64DXSM(1483336117))
+    return np.random.Generator(np.random.PCG64DXSM(1481236117))

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -224,7 +224,7 @@ def test_stack_zip_sp_matmul_topn(rng, dtype):
     C_ref = sp_matmul_topn(A, B.T, top_n=10, threshold=0.01, sort=True)
 
     # zipped C-matrix
-    As = [A[i*200:(i+1)*200] for i in range(5)]  # names-to-match split
+    As = [A[i * 200 : (i + 1) * 200] for i in range(5)]  # names-to-match split
     Bs = [B[:100], B[100:300], B[300:]]  # GT split
 
     Cs = [[sp_matmul_topn(Aj, Bi.T, top_n=10, threshold=0.01, sort=True) for Bi in Bs] for Aj in As]


### PR DESCRIPTION
An undocumented change in Scipy 1.13 caused the tests to fail because a column in a sub-matrix contained all zero values.
This is fixed by setting the shape during the matrix creation.

The random seed had to be changed because one of the randomly generated matrices with float precision had two entries with identical values which caused resulted in different ordering of the indices.
