### PR TITLE
CICD: Add trusted publishing and updated MacOS runners

### DIFF
--- a/.github/workflows/nonvendored_wheels.yml
+++ b/.github/workflows/nonvendored_wheels.yml
@@ -45,9 +45,11 @@ jobs:
         submodules: true
 
     - uses: actions/setup-python@v5
+      with:
+        python-version: "3.10"
 
     - name: Install cibuildwheel
-      run: python -m pip install cibuildwheel==2.17.0
+      run: python -m pip install cibuildwheel==2.18.0
 
     - name: Build wheels
       run: python -m cibuildwheel --output-dir wheelhouse

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -56,7 +56,7 @@ jobs:
         CIBW_TEST_COMMAND: pytest {project}/tests && python -c "from sparse_dot_topn import _has_openmp_support;assert _has_openmp_support"
         # only build for x86_64; ARM wheels are build seperately
         CIBW_ARCHS_MACOS: "x86_64"
-        CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET="10.14" CMAKE_ARGS="-DSDTN_ENABLE_ARCH_FLAGS=OFF -DSDTN_ENABLE_OPENMP=ON -DSDTN_DISABLE_OPENMP=OFF"
+        CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET="12.0" CMAKE_ARGS="-DSDTN_ENABLE_ARCH_FLAGS=OFF -DSDTN_ENABLE_OPENMP=ON -DSDTN_DISABLE_OPENMP=OFF"
 
     - name: Verify clean directory
       run: git diff --exit-code
@@ -100,7 +100,7 @@ jobs:
         mkdir openmp_build
         cmake -S openmp -B openmp_build \
             -DCMAKE_OSX_ARCHITECTURES="arm64" \
-            -DCMAKE_OSX_DEPLOYMENT_TARGET="10.14" \
+            -DCMAKE_OSX_DEPLOYMENT_TARGET="12.0" \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_C_COMPILER=clang \
             -DCMAKE_CXX_COMPILER=clang++ \
@@ -111,7 +111,7 @@ jobs:
       env:
         # only build for ARM; x86_64wheels are build seperately
         CIBW_ARCHS: "arm64"
-        CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET="10.14" CMAKE_ARGS="-DSDTN_ENABLE_ARCH_FLAGS=OFF -DSDTN_ENABLE_OPENMP=ON -DSDTN_DISABLE_OPENMP=OFF -DOpenMP_ROOT=/usr/local"
+        CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET="12.0" CMAKE_ARGS="-DSDTN_ENABLE_ARCH_FLAGS=OFF -DSDTN_ENABLE_OPENMP=ON -DSDTN_DISABLE_OPENMP=OFF -DOpenMP_ROOT=/usr/local"
 
     - name: Verify clean directory
       run: git diff --exit-code

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-13, windows-latest]
 
     steps:
     - uses: actions/checkout@v4
@@ -54,8 +54,8 @@ jobs:
       env:
         CIBW_ENVIRONMENT: CMAKE_ARGS="-DSDTN_ENABLE_ARCH_FLAGS=OFF -DSDTN_ENABLE_OPENMP=ON -DSDTN_DISABLE_OPENMP=OFF"
         CIBW_TEST_COMMAND: pytest {project}/tests && python -c "from sparse_dot_topn import _has_openmp_support;assert _has_openmp_support"
-        # only build for x86_64; ARM wheels are build seperately
-        CIBW_ARCHS_MACOS: "x86_64"
+        # only build for arm; x86_64 wheels are build seperately
+        CIBW_ARCHS_MACOS: "arm64"
         CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET="12.0" CMAKE_ARGS="-DSDTN_ENABLE_ARCH_FLAGS=OFF -DSDTN_ENABLE_OPENMP=ON -DSDTN_DISABLE_OPENMP=OFF"
 
     - name: Verify clean directory
@@ -68,9 +68,9 @@ jobs:
         name: artifact-${{ matrix.os }}
         path: wheelhouse/*.whl
 
-  build_arm_wheels:
-    name: MacOS ARM wheels
-    runs-on: macos-latest
+  build_macos_intel:
+    name: MacOS x86_64 wheels
+    runs-on: macos-13
     strategy:
       fail-fast: false
 
@@ -79,39 +79,11 @@ jobs:
       with:
         submodules: true
 
-    - name: Cache OpenMP repo
-      id: clone-openmp
-      uses: actions/cache@v4
-      with:
-        path: llvm-project
-        key: macos-arm-openmp
-
-    - name: Clone OpenMP repo
-      if: steps.clone-openmp.outputs.cache-hit != 'true'
-      run: |
-        git clone --depth 1 --branch llvmorg-17.0.6 https://github.com/llvm/llvm-project
-
-    - name: Build OpenMP
-      shell: bash
-      run: |
-        mv llvm-project/openmp ./openmp
-        mv llvm-project/cmake ./cmake
-        rm -rf llvm-project
-        mkdir openmp_build
-        cmake -S openmp -B openmp_build \
-            -DCMAKE_OSX_ARCHITECTURES="arm64" \
-            -DCMAKE_OSX_DEPLOYMENT_TARGET="12.0" \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_C_COMPILER=clang \
-            -DCMAKE_CXX_COMPILER=clang++ \
-            -DCMAKE_INSTALL_PREFIX="/usr/local"
-        cmake --build openmp_build --target install --config Release
-
     - uses: pypa/cibuildwheel@v2.17.0
       env:
-        # only build for ARM; x86_64wheels are build seperately
-        CIBW_ARCHS: "arm64"
-        CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET="12.0" CMAKE_ARGS="-DSDTN_ENABLE_ARCH_FLAGS=OFF -DSDTN_ENABLE_OPENMP=ON -DSDTN_DISABLE_OPENMP=OFF -DOpenMP_ROOT=/usr/local"
+        # only build for x86_64, arm wheels are build seperately
+        CIBW_ARCHS: "x86_64"
+        CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET="12.0" CMAKE_ARGS="-DSDTN_ENABLE_ARCH_FLAGS=OFF -DSDTN_ENABLE_OPENMP=ON -DSDTN_DISABLE_OPENMP=OFF"
 
     - name: Verify clean directory
       run: git diff --exit-code
@@ -120,12 +92,12 @@ jobs:
     - name: Upload wheels
       uses: actions/upload-artifact@v4
       with:
-        name: artifact-macos-arm
+        name: artifact-macos-x86-64
         path: wheelhouse/*.whl
 
   upload_all:
     name: Upload if release
-    needs: [build_sdist, build_wheels, build_arm_wheels]
+    needs: [build_sdist, build_wheels, build_macos_intel]
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'published'
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -157,11 +157,38 @@ jobs:
         name: artifact-macos-x86-64
         path: wheelhouse/*.whl
 
-  upload_all:
-    name: Upload if release
+  publish-to-testpypi:
+    name: Publish release on TestPyPi
     needs: [build_sdist, build_wheels, build_macos_intel]
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'ing-bank' && github.event_name == 'release' # prevent forks from running this step
+    environment: testrelease
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+
+    steps:
+    - uses: actions/setup-python@v5
+      with:
+        python-version: "3.10"
+    - uses: actions/download-artifact@v4
+      with:
+        pattern: artifact-*
+        merge-multiple: true
+        path: dist
+
+    - uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/
+        skip-existing: true
+
+  pypi-publish:
+    name: Publish release on PyPi
+    needs: [build_sdist, build_wheels, build_macos_intel, publish-to-testpypi]
+    runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'published'
+    environment: release
+    permissions:
+      id-token: write
 
     steps:
     - uses: actions/setup-python@v5
@@ -176,5 +203,4 @@ jobs:
 
     - uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        user: ${{ secrets.PYPI_USER }}
-        password: ${{ secrets.PYPI_PASS }}
+        skip-existing: true

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -45,6 +45,8 @@ jobs:
         submodules: true
 
     - uses: actions/setup-python@v5
+      with:
+        python-version: "3.10"
 
     - name: Cache OpenMP repo
       if: matrix.os == 'macos-latest'
@@ -79,7 +81,7 @@ jobs:
         cmake --build openmp_build --target install --config Release
 
     - name: Install cibuildwheel
-      run: python -m pip install cibuildwheel==2.17.0
+      run: python -m pip install cibuildwheel==2.18.0
 
     - name: Build wheels
       run: python -m cibuildwheel --output-dir wheelhouse
@@ -139,7 +141,7 @@ jobs:
             -DCMAKE_INSTALL_PREFIX="/usr/local"
         cmake --build openmp_build --target install --config Release
 
-    - uses: pypa/cibuildwheel@v2.17.0
+    - uses: pypa/cibuildwheel@v2.18.0
       env:
         # only build for x86_64, arm wheels are build seperately
         CIBW_ARCHS: "x86_64"
@@ -163,6 +165,8 @@ jobs:
 
     steps:
     - uses: actions/setup-python@v5
+      with:
+        python-version: "3.10"
 
     - uses: actions/download-artifact@v4
       with:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-13, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
     - uses: actions/checkout@v4
@@ -45,6 +45,38 @@ jobs:
         submodules: true
 
     - uses: actions/setup-python@v5
+
+    - name: Cache OpenMP repo
+      if: matrix.os == 'macos-latest'
+      id: clone-openmp
+      uses: actions/cache@v4
+      with:
+        path: llvm-project
+        key: ${{ runner.os }}-openmp
+
+    - name: Clone OpenMP repo
+      if: matrix.os == 'macos-latest' && steps.clone-openmp.outputs.cache-hit != 'true'
+      run: |
+        git clone --depth 1 --branch llvmorg-17.0.6 https://github.com/llvm/llvm-project
+
+
+    - name: Build OpenMP
+      if: matrix.os == 'macos-latest'
+      shell: bash
+      run: |
+        PATH="$HOME/.local/:$PATH"
+        mv llvm-project/openmp ./openmp
+        mv llvm-project/cmake ./cmake
+        rm -rf llvm-project
+        mkdir openmp_build
+        cmake -S openmp -B openmp_build \
+            -DCMAKE_OSX_ARCHITECTURES="arm64" \
+            -DCMAKE_OSX_DEPLOYMENT_TARGET="12.0" \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_COMPILER=clang \
+            -DCMAKE_CXX_COMPILER=clang++ \
+            -DCMAKE_INSTALL_PREFIX="$HOME/.local/libomp"
+        cmake --build openmp_build --target install --config Release
 
     - name: Install cibuildwheel
       run: python -m pip install cibuildwheel==2.17.0
@@ -56,7 +88,7 @@ jobs:
         CIBW_TEST_COMMAND: pytest {project}/tests && python -c "from sparse_dot_topn import _has_openmp_support;assert _has_openmp_support"
         # only build for arm; x86_64 wheels are build seperately
         CIBW_ARCHS_MACOS: "arm64"
-        CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET="12.0" CMAKE_ARGS="-DSDTN_ENABLE_ARCH_FLAGS=OFF -DSDTN_ENABLE_OPENMP=ON -DSDTN_DISABLE_OPENMP=OFF"
+        CIBW_ENVIRONMENT_MACOS: PATH="$HOME/.local/:$PATH" MACOSX_DEPLOYMENT_TARGET="12.0" DYLD_LIBRARY_PATH="$HOME/.local/libomp/lib" CMAKE_ARGS="-DSDTN_ENABLE_ARCH_FLAGS=OFF -DSDTN_ENABLE_OPENMP=ON -DSDTN_DISABLE_OPENMP=OFF -DOpenMP_ROOT=$HOME/.local/libomp"
 
     - name: Verify clean directory
       run: git diff --exit-code
@@ -79,11 +111,39 @@ jobs:
       with:
         submodules: true
 
+    - name: Cache OpenMP repo
+      id: clone-openmp
+      uses: actions/cache@v4
+      with:
+        path: llvm-project
+        key: ${{ runner.os }}-openmp
+
+    - name: Clone OpenMP repo
+      if: steps.clone-openmp.outputs.cache-hit != 'true'
+      run: |
+        git clone --depth 1 --branch llvmorg-17.0.6 https://github.com/llvm/llvm-project
+
+    - name: Build OpenMP
+      shell: bash
+      run: |
+        mv llvm-project/openmp ./openmp
+        mv llvm-project/cmake ./cmake
+        rm -rf llvm-project
+        mkdir openmp_build
+        cmake -S openmp -B openmp_build \
+            -DCMAKE_OSX_ARCHITECTURES="x86_64" \
+            -DCMAKE_OSX_DEPLOYMENT_TARGET="12.0" \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_COMPILER=clang \
+            -DCMAKE_CXX_COMPILER=clang++ \
+            -DCMAKE_INSTALL_PREFIX="/usr/local"
+        cmake --build openmp_build --target install --config Release
+
     - uses: pypa/cibuildwheel@v2.17.0
       env:
         # only build for x86_64, arm wheels are build seperately
         CIBW_ARCHS: "x86_64"
-        CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET="12.0" CMAKE_ARGS="-DSDTN_ENABLE_ARCH_FLAGS=OFF -DSDTN_ENABLE_OPENMP=ON -DSDTN_DISABLE_OPENMP=OFF"
+        CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET="12.0" CMAKE_ARGS="-DSDTN_ENABLE_ARCH_FLAGS=OFF -DSDTN_ENABLE_OPENMP=ON -DSDTN_DISABLE_OPENMP=OFF -DOpenMP_ROOT=/usr/local"
 
     - name: Verify clean directory
       run: git diff --exit-code

--- a/README.md
+++ b/README.md
@@ -67,8 +67,9 @@ pip install sparse_dot_topn
 ```
 
 **sparse\_dot\_topn** relies on a C++ extension for the computationally intensive multiplication routine.
-Note that the wheels vendor/ships OpenMP with the extension to provide parallelisation out-of-the-box.
-If you run into issues with OpenMP see INSTALLATION.md for help.
+**Note that the wheels vendor/ships OpenMP with the extension to provide parallelisation out-of-the-box.**
+**This may cause issues when used in combination with other libraries that ship OpenMP like PyTorch.**
+If you run into any issues with OpenMP see INSTALLATION.md for help or run the function without specifying the `n_threads` argument.
 
 Installing from source requires a C++17 compatible compiler.
 If you have a compiler available it is advised to install without the wheel as this enables architecture specific optimisations.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ sdist.include = [
 wheel.py-api = "cp312"
 
 [tool.scikit-build.cmake.define]
-CMAKE_OSX_DEPLOYMENT_TARGET="10.14"
+CMAKE_OSX_DEPLOYMENT_TARGET="12.0"
 SDTN_CPP_STANDARD = "17"
 SDTN_ENABLE_DEVMODE = false
 SDTN_ENABLE_DEBUG = false
@@ -77,7 +77,7 @@ repair-wheel-command = "auditwheel repair -w {dest_dir} {wheel}"
 [tool.cibuildwheel.macos]
 archs = ["x86_64", "arm64"]
 # Needed for full C++17 support
-environment = { MACOSX_DEPLOYMENT_TARGET = "10.14", CMAKE_ARGS="-DSDTN_ENABLE_ARCH_FLAGS=OFF -DSDTN_DISABLE_OPENMP=ON" }
+environment = { MACOSX_DEPLOYMENT_TARGET = "12.0", CMAKE_ARGS="-DSDTN_ENABLE_ARCH_FLAGS=OFF -DSDTN_DISABLE_OPENMP=ON" }
 repair-wheel-command = "delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}"
 
 [tool.cibuildwheel.windows]


### PR DESCRIPTION
Supersedes #105 #106

## Changes

- CICD: Update wheel builds to support new MacOS runners with Apple silicon support
- CICD: Switch to trusted publishing to PyPi