### PR TITLE
BLD: Restrict nanobind version to <2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["scikit-build-core >=0.4.3", "nanobind >=1.3.2"]
+requires = ["scikit-build-core >=0.4.3", "nanobind >=1.3.2,<2.0.0"]
 build-backend = "scikit_build_core.build"
 
 [project]

--- a/src/sparse_dot_topn_core/include/sparse_dot_topn/maxheap.hpp
+++ b/src/sparse_dot_topn_core/include/sparse_dot_topn/maxheap.hpp
@@ -59,7 +59,7 @@ class MaxHeap {
      * \param initial initial `val` to set for all the entries
      */
     explicit MaxHeap(int n, eT initial) : heap_size{n}, init{initial} {
-        heap.reserve(n);
+        heap.reserve(n + 1);
         for (int i = 0; i < heap_size; i++) {
             heap.push_back({max_order, -1, initial});
         }


### PR DESCRIPTION
PR to temporarily restrict Nanobind to v1 as v2 introduces breaking changes which we need to adapt to.