### PR TITLE
BLD: Unrestrict nanobind

### DIFF
--- a/.github/workflows/numpy.yml
+++ b/.github/workflows/numpy.yml
@@ -1,0 +1,32 @@
+name: Test NumPy
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build
+    runs-on: ${{ matrix.platform }}
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [windows-latest, macos-latest, ubuntu-latest]
+        numpy-version: ["numpy<2.0.0", "numpy~=2.0.0rc2"]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+
+    - name: Build and install
+      run: |
+        pip install pip --upgrade
+        pip install "${{ matrix.numpy-version }}"
+        pip install ".[test]" --verbose 
+
+    - name: Test
+      run: |
+        cd tests
+        pytest -vv

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,27 @@
 # Release history:
 
+## v1.1.3
+
+### Changes
+
+BLD: Unrestrict nanobind by @RUrlus in #112
+
+### Internal
+
+FIX: [C++] Remove usage of nb::raw_doc
+
+## v1.1.2
+
+### Changes
+
+BLD: Restrict nanobind version to <2.0 by @RUrlus in #111
+
+### Internal
+
+CICD: Add trusted publishing and updated MacOS runners by @RUrlus in #108
+MAINT: Correct name typo in readme by @mmtevelde in #110
+CICD: Bump pypa/cibuildwheel from 2.18.0 to 2.18.1 by @dependabot in #109
+
 ## v1.1.1
 
 ### Internal

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["scikit-build-core >=0.4.3", "nanobind >=1.3.2,<2.0.0"]
+requires = ["scikit-build-core >=0.4.3", "nanobind >=1.3.2"]
 build-backend = "scikit_build_core.build"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "sparse_dot_topn"
-version = "1.1.2"
+version = "1.1.3"
 description = "This package boosts a sparse matrix multiplication followed by selecting the top-n multiplication"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/sparse_dot_topn_core/src/sp_matmul_bindings.cpp
+++ b/src/sparse_dot_topn_core/src/sp_matmul_bindings.cpp
@@ -36,25 +36,23 @@ void bind_sp_matmul(nb::module_& m) {
         "B_data"_a.noconvert(),
         "B_indptr"_a.noconvert(),
         "B_indices"_a.noconvert(),
-        nb::raw_doc(
-            "Compute sparse dot product and keep top n.\n"
-            "\n"
-            "Args:\n"
-            "    nrows (int): the number of rows in `A`\n"
-            "    ncols (int): the number of columns in `B`\n"
-            "    A_data (NDArray[int | float]): the non-zero elements of A\n"
-            "    A_indptr (NDArray[int]): the row indices for `A_data`\n"
-            "    A_indices (NDArray[int]): the column indices for `A_data`\n"
-            "    B_data (NDArray[int | float]): the non-zero elements of B\n"
-            "    B_indptr (NDArray[int]): the row indices for `B_data`\n"
-            "    B_indices (NDArray[int]): the column indices for `B_data`\n"
-            "\n"
-            "Returns:\n"
-            "    C_data (NDArray[int | float]): the non-zero elements of C\n"
-            "    C_indptr (NDArray[int]): the row indices for `C_data`\n"
-            "    C_indices (NDArray[int]): the column indices for `C_data`\n"
-            "\n"
-        )
+        ("Compute sparse dot product and keep top n.\n"
+         "\n"
+         "Args:\n"
+         "    nrows (int): the number of rows in `A`\n"
+         "    ncols (int): the number of columns in `B`\n"
+         "    A_data (NDArray[int | float]): the non-zero elements of A\n"
+         "    A_indptr (NDArray[int]): the row indices for `A_data`\n"
+         "    A_indices (NDArray[int]): the column indices for `A_data`\n"
+         "    B_data (NDArray[int | float]): the non-zero elements of B\n"
+         "    B_indptr (NDArray[int]): the row indices for `B_data`\n"
+         "    B_indices (NDArray[int]): the column indices for `B_data`\n"
+         "\n"
+         "Returns:\n"
+         "    C_data (NDArray[int | float]): the non-zero elements of C\n"
+         "    C_indptr (NDArray[int]): the row indices for `C_data`\n"
+         "    C_indices (NDArray[int]): the column indices for `C_data`\n"
+         "\n")
     );
     m.def(
         "sp_matmul",
@@ -156,25 +154,23 @@ void bind_sp_matmul_mt(nb::module_& m) {
         "B_data"_a.noconvert(),
         "B_indptr"_a.noconvert(),
         "B_indices"_a.noconvert(),
-        nb::raw_doc(
-            "Compute sparse dot product and keep top n.\n"
-            "\n"
-            "Args:\n"
-            "    nrows (int): the number of rows in `A`\n"
-            "    ncols (int): the number of columns in `B`\n"
-            "    A_data (NDArray[int | float]): the non-zero elements of A\n"
-            "    A_indptr (NDArray[int]): the row indices for `A_data`\n"
-            "    A_indices (NDArray[int]): the column indices for `A_data`\n"
-            "    B_data (NDArray[int | float]): the non-zero elements of B\n"
-            "    B_indptr (NDArray[int]): the row indices for `B_data`\n"
-            "    B_indices (NDArray[int]): the column indices for `B_data`\n"
-            "\n"
-            "Returns:\n"
-            "    C_data (NDArray[int | float]): the non-zero elements of C\n"
-            "    C_indptr (NDArray[int]): the row indices for `C_data`\n"
-            "    C_indices (NDArray[int]): the column indices for `C_data`\n"
-            "\n"
-        )
+        ("Compute sparse dot product and keep top n.\n"
+         "\n"
+         "Args:\n"
+         "    nrows (int): the number of rows in `A`\n"
+         "    ncols (int): the number of columns in `B`\n"
+         "    A_data (NDArray[int | float]): the non-zero elements of A\n"
+         "    A_indptr (NDArray[int]): the row indices for `A_data`\n"
+         "    A_indices (NDArray[int]): the column indices for `A_data`\n"
+         "    B_data (NDArray[int | float]): the non-zero elements of B\n"
+         "    B_indptr (NDArray[int]): the row indices for `B_data`\n"
+         "    B_indices (NDArray[int]): the column indices for `B_data`\n"
+         "\n"
+         "Returns:\n"
+         "    C_data (NDArray[int | float]): the non-zero elements of C\n"
+         "    C_indptr (NDArray[int]): the row indices for `C_data`\n"
+         "    C_indices (NDArray[int]): the column indices for `C_data`\n"
+         "\n")
     );
     m.def(
         "sp_matmul_mt",

--- a/src/sparse_dot_topn_core/src/sp_matmul_topn_bindings.cpp
+++ b/src/sparse_dot_topn_core/src/sp_matmul_topn_bindings.cpp
@@ -39,29 +39,27 @@ void bind_sp_matmul_topn(nb::module_& m) {
         "B_data"_a.noconvert(),
         "B_indptr"_a.noconvert(),
         "B_indices"_a.noconvert(),
-        nb::raw_doc(
-            "Compute sparse dot product and keep top n.\n"
-            "\n"
-            "Args:\n"
-            "    top_n (int): the number of results to retain\n"
-            "    nrows (int): the number of rows in `A`\n"
-            "    ncols (int): the number of columns in `B`\n"
-            "    density (float): the expected density of the result"
-            " considering `top_n`\n"
-            "    threshold (float): only store values greater than\n"
-            "    A_data (NDArray[int | float]): the non-zero elements of A\n"
-            "    A_indptr (NDArray[int]): the row indices for `A_data`\n"
-            "    A_indices (NDArray[int]): the column indices for `A_data`\n"
-            "    B_data (NDArray[int | float]): the non-zero elements of B\n"
-            "    B_indptr (NDArray[int]): the row indices for `B_data`\n"
-            "    B_indices (NDArray[int]): the column indices for `B_data`\n"
-            "\n"
-            "Returns:\n"
-            "    C_data (NDArray[int | float]): the non-zero elements of C\n"
-            "    C_indptr (NDArray[int]): the row indices for `C_data`\n"
-            "    C_indices (NDArray[int]): the column indices for `C_data`\n"
-            "\n"
-        )
+        ("Compute sparse dot product and keep top n.\n"
+         "\n"
+         "Args:\n"
+         "    top_n (int): the number of results to retain\n"
+         "    nrows (int): the number of rows in `A`\n"
+         "    ncols (int): the number of columns in `B`\n"
+         "    density (float): the expected density of the result"
+         " considering `top_n`\n"
+         "    threshold (float): only store values greater than\n"
+         "    A_data (NDArray[int | float]): the non-zero elements of A\n"
+         "    A_indptr (NDArray[int]): the row indices for `A_data`\n"
+         "    A_indices (NDArray[int]): the column indices for `A_data`\n"
+         "    B_data (NDArray[int | float]): the non-zero elements of B\n"
+         "    B_indptr (NDArray[int]): the row indices for `B_data`\n"
+         "    B_indices (NDArray[int]): the column indices for `B_data`\n"
+         "\n"
+         "Returns:\n"
+         "    C_data (NDArray[int | float]): the non-zero elements of C\n"
+         "    C_indptr (NDArray[int]): the row indices for `C_data`\n"
+         "    C_indices (NDArray[int]): the column indices for `C_data`\n"
+         "\n")
     );
     m.def(
         "sp_matmul_topn",
@@ -185,29 +183,27 @@ void bind_sp_matmul_topn_sorted(nb::module_& m) {
         "B_data"_a.noconvert(),
         "B_indptr"_a.noconvert(),
         "B_indices"_a.noconvert(),
-        nb::raw_doc(
-            "Compute sparse dot product and keep top n.\n"
-            "\n"
-            "Args:\n"
-            "    top_n (int): the number of results to retain\n"
-            "    nrows (int): the number of rows in `A`\n"
-            "    ncols (int): the number of columns in `B`\n"
-            "    threshold (float): only store values greater than\n"
-            "    density (float): the expected density of the result"
-            " considering `top_n`\n"
-            "    A_data (NDArray[int | float]): the non-zero elements of A\n"
-            "    A_indptr (NDArray[int]): the row indices for `A_data`\n"
-            "    A_indices (NDArray[int]): the column indices for `A_data`\n"
-            "    B_data (NDArray[int | float]): the non-zero elements of B\n"
-            "    B_indptr (NDArray[int]): the row indices for `B_data`\n"
-            "    B_indices (NDArray[int]): the column indices for `B_data`\n"
-            "\n"
-            "Returns:\n"
-            "    C_data (NDArray[int | float]): the non-zero elements of C\n"
-            "    C_indptr (NDArray[int]): the row indices for `C_data`\n"
-            "    C_indices (NDArray[int]): the column indices for `C_data`\n"
-            "\n"
-        )
+        ("Compute sparse dot product and keep top n.\n"
+         "\n"
+         "Args:\n"
+         "    top_n (int): the number of results to retain\n"
+         "    nrows (int): the number of rows in `A`\n"
+         "    ncols (int): the number of columns in `B`\n"
+         "    threshold (float): only store values greater than\n"
+         "    density (float): the expected density of the result"
+         " considering `top_n`\n"
+         "    A_data (NDArray[int | float]): the non-zero elements of A\n"
+         "    A_indptr (NDArray[int]): the row indices for `A_data`\n"
+         "    A_indices (NDArray[int]): the column indices for `A_data`\n"
+         "    B_data (NDArray[int | float]): the non-zero elements of B\n"
+         "    B_indptr (NDArray[int]): the row indices for `B_data`\n"
+         "    B_indices (NDArray[int]): the column indices for `B_data`\n"
+         "\n"
+         "Returns:\n"
+         "    C_data (NDArray[int | float]): the non-zero elements of C\n"
+         "    C_indptr (NDArray[int]): the row indices for `C_data`\n"
+         "    C_indices (NDArray[int]): the column indices for `C_data`\n"
+         "\n")
     );
     m.def(
         "sp_matmul_topn_sorted",
@@ -332,27 +328,25 @@ void bind_sp_matmul_topn_mt(nb::module_& m) {
         "B_data"_a.noconvert(),
         "B_indptr"_a.noconvert(),
         "B_indices"_a.noconvert(),
-        nb::raw_doc(
-            "Compute sparse dot product and keep top n.\n"
-            "\n"
-            "Args:\n"
-            "    top_n (int): the number of results to retain\n"
-            "    nrows (int): the number of rows in `A`\n"
-            "    ncols (int): the number of columns in `B`\n"
-            "    threshold (float): only store values greater than\n"
-            "    A_data (NDArray[int | float]): the non-zero elements of A\n"
-            "    A_indptr (NDArray[int]): the row indices for `A_data`\n"
-            "    A_indices (NDArray[int]): the column indices for `A_data`\n"
-            "    B_data (NDArray[int | float]): the non-zero elements of B\n"
-            "    B_indptr (NDArray[int]): the row indices for `B_data`\n"
-            "    B_indices (NDArray[int]): the column indices for `B_data`\n"
-            "\n"
-            "Returns:\n"
-            "    C_data (NDArray[int | float]): the non-zero elements of C\n"
-            "    C_indptr (NDArray[int]): the row indices for `C_data`\n"
-            "    C_indices (NDArray[int]): the column indices for `C_data`\n"
-            "\n"
-        )
+        ("Compute sparse dot product and keep top n.\n"
+         "\n"
+         "Args:\n"
+         "    top_n (int): the number of results to retain\n"
+         "    nrows (int): the number of rows in `A`\n"
+         "    ncols (int): the number of columns in `B`\n"
+         "    threshold (float): only store values greater than\n"
+         "    A_data (NDArray[int | float]): the non-zero elements of A\n"
+         "    A_indptr (NDArray[int]): the row indices for `A_data`\n"
+         "    A_indices (NDArray[int]): the column indices for `A_data`\n"
+         "    B_data (NDArray[int | float]): the non-zero elements of B\n"
+         "    B_indptr (NDArray[int]): the row indices for `B_data`\n"
+         "    B_indices (NDArray[int]): the column indices for `B_data`\n"
+         "\n"
+         "Returns:\n"
+         "    C_data (NDArray[int | float]): the non-zero elements of C\n"
+         "    C_indptr (NDArray[int]): the row indices for `C_data`\n"
+         "    C_indices (NDArray[int]): the column indices for `C_data`\n"
+         "\n")
     );
     m.def(
         "sp_matmul_topn_mt",
@@ -476,27 +470,25 @@ void bind_sp_matmul_topn_sorted_mt(nb::module_& m) {
         "B_data"_a.noconvert(),
         "B_indptr"_a.noconvert(),
         "B_indices"_a.noconvert(),
-        nb::raw_doc(
-            "Compute sparse dot product and keep top n.\n"
-            "\n"
-            "Args:\n"
-            "    top_n (int): the number of results to retain\n"
-            "    nrows (int): the number of rows in `A`\n"
-            "    ncols (int): the number of columns in `B`\n"
-            "    threshold (float): only store values greater than\n"
-            "    A_data (NDArray[int | float]): the non-zero elements of A\n"
-            "    A_indptr (NDArray[int]): the row indices for `A_data`\n"
-            "    A_indices (NDArray[int]): the column indices for `A_data`\n"
-            "    B_data (NDArray[int | float]): the non-zero elements of B\n"
-            "    B_indptr (NDArray[int]): the row indices for `B_data`\n"
-            "    B_indices (NDArray[int]): the column indices for `B_data`\n"
-            "\n"
-            "Returns:\n"
-            "    C_data (NDArray[int | float]): the non-zero elements of C\n"
-            "    C_indptr (NDArray[int]): the row indices for `C_data`\n"
-            "    C_indices (NDArray[int]): the column indices for `C_data`\n"
-            "\n"
-        )
+        ("Compute sparse dot product and keep top n.\n"
+         "\n"
+         "Args:\n"
+         "    top_n (int): the number of results to retain\n"
+         "    nrows (int): the number of rows in `A`\n"
+         "    ncols (int): the number of columns in `B`\n"
+         "    threshold (float): only store values greater than\n"
+         "    A_data (NDArray[int | float]): the non-zero elements of A\n"
+         "    A_indptr (NDArray[int]): the row indices for `A_data`\n"
+         "    A_indices (NDArray[int]): the column indices for `A_data`\n"
+         "    B_data (NDArray[int | float]): the non-zero elements of B\n"
+         "    B_indptr (NDArray[int]): the row indices for `B_data`\n"
+         "    B_indices (NDArray[int]): the column indices for `B_data`\n"
+         "\n"
+         "Returns:\n"
+         "    C_data (NDArray[int | float]): the non-zero elements of C\n"
+         "    C_indptr (NDArray[int]): the row indices for `C_data`\n"
+         "    C_indices (NDArray[int]): the column indices for `C_data`\n"
+         "\n")
     );
     m.def(
         "sp_matmul_topn_sorted_mt",

--- a/src/sparse_dot_topn_core/src/zip_sp_matmul_topn_bindings.cpp
+++ b/src/sparse_dot_topn_core/src/zip_sp_matmul_topn_bindings.cpp
@@ -35,28 +35,26 @@ void bind_zip_sp_matmul_topn(nb::module_& m) {
         "data"_a.noconvert(),
         "indptr"_a.noconvert(),
         "indices"_a.noconvert(),
-        nb::raw_doc(
-            "Compute sparse dot product and keep top n.\n"
-            "\n"
-            "Args:\n"
-            "    top_n (int): the number of results to retain\n"
-            "    Z_max_nnz (int): the maximum number of non-zero values in Z\n"
-            "    nrows (int): the number of rows in `A`\n"
-            "    B_ncols (NDArray[int]): the number of columns in each block "
-            "of `B`\n"
-            "    data (list[NDArray[int | float]]): the non-zero elements of "
-            "each C\n"
-            "    indptr (list[NDArray[int]]): the row indices for each "
-            "`C_data`\n"
-            "    indices (list[NDArray[int]]): the column indices for each "
-            "`C_data`\n"
-            "\n"
-            "Returns:\n"
-            "    Z_data (NDArray[int | float]): the non-zero elements of Z\n"
-            "    Z_indptr (NDArray[int]): the row indices for `Z_data`\n"
-            "    Z_indices (NDArray[int]): the column indices for `Z_data`\n"
-            "\n"
-        )
+        ("Compute sparse dot product and keep top n.\n"
+         "\n"
+         "Args:\n"
+         "    top_n (int): the number of results to retain\n"
+         "    Z_max_nnz (int): the maximum number of non-zero values in Z\n"
+         "    nrows (int): the number of rows in `A`\n"
+         "    B_ncols (NDArray[int]): the number of columns in each block "
+         "of `B`\n"
+         "    data (list[NDArray[int | float]]): the non-zero elements of "
+         "each C\n"
+         "    indptr (list[NDArray[int]]): the row indices for each "
+         "`C_data`\n"
+         "    indices (list[NDArray[int]]): the column indices for each "
+         "`C_data`\n"
+         "\n"
+         "Returns:\n"
+         "    Z_data (NDArray[int | float]): the non-zero elements of Z\n"
+         "    Z_indptr (NDArray[int]): the row indices for `Z_data`\n"
+         "    Z_indices (NDArray[int]): the column indices for `Z_data`\n"
+         "\n")
     );
     m.def(
         "zip_sp_matmul_topn",


### PR DESCRIPTION
Adds support for Nanobind v2 by removing usage of `nb::raw_doc`, closes #112 