### PR TITLE
DEP: Drop support for CPython 3.9 in line nanobind

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -3,7 +3,7 @@ name: Linux
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 23 * * 1'
+    - cron: "0 23 * * 1"
 
 jobs:
   tests:
@@ -12,21 +12,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
-    - uses: actions/checkout@v7
+      - uses: actions/checkout@v7
 
-    - uses: actions/setup-python@v7
-      with:
-        python-version: ${{ matrix.python-version }}
+      - uses: actions/setup-python@v7
+        with:
+          python-version: ${{ matrix.python-version }}
 
-    - name: Build and install
-      run: |
-        pip install pip --upgrade
-        pip install ".[test]" --verbose 
+      - name: Build and install
+        run: |
+          pip install pip --upgrade
+          pip install ".[test]" --verbose
 
-    - name: Test
-      run: |
-        cd tests
-        pytest -vv
+      - name: Test
+        run: |
+          cd tests
+          pytest -vv

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -3,7 +3,7 @@ name: MacOS
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 23 * * 1'
+    - cron: "0 23 * * 1"
 
 jobs:
   tests:
@@ -12,22 +12,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
-
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
-    - uses: actions/checkout@v7
+      - uses: actions/checkout@v7
 
-    - uses: actions/setup-python@v7
-      with:
-        python-version: ${{ matrix.python-version }}
+      - uses: actions/setup-python@v7
+        with:
+          python-version: ${{ matrix.python-version }}
 
-    - name: Build and install
-      run: |
-        pip install pip --upgrade
-        pip install ".[test]" --verbose 
+      - name: Build and install
+        run: |
+          pip install pip --upgrade
+          pip install ".[test]" --verbose
 
-    - name: Test
-      run: |
-        cd tests
-        pytest -vv
+      - name: Test
+        run: |
+          cd tests
+          pytest -vv

--- a/.github/workflows/nonvendored_wheels.yml
+++ b/.github/workflows/nonvendored_wheels.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
   push:
     branches:
-     - main
+      - main
   release:
     types:
       - published
@@ -15,21 +15,20 @@ jobs:
     name: Build SDist
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7
-      with:
-        submodules: true
+      - uses: actions/checkout@v7
+        with:
+          submodules: true
 
-    - name: Build SDist
-      run: pipx run build --sdist
+      - name: Build SDist
+        run: pipx run build --sdist
 
-    - name: Check metadata
-      run: pipx run twine check dist/*
+      - name: Check metadata
+        run: pipx run twine check dist/*
 
-    - uses: actions/upload-artifact@v7
-      with:
-        name: artifact-sdist
-        path: dist/*.tar.gz
-
+      - uses: actions/upload-artifact@v7
+        with:
+          name: artifact-sdist
+          path: dist/*.tar.gz
 
   build_wheels:
     name: Wheels on ${{ matrix.os }}
@@ -40,33 +39,32 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
-    - uses: actions/checkout@v7
-      with:
-        submodules: true
+      - uses: actions/checkout@v7
+        with:
+          submodules: true
 
-    - uses: actions/setup-python@v7
-      with:
-        python-version: "3.11"
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.11"
 
-    - name: Install cibuildwheel
-      run: python -m pip install cibuildwheel>=3.3.0
+      - name: Install cibuildwheel
+        run: python -m pip install cibuildwheel>=3.3.0
 
-    - name: Build wheels
-      run: python -m cibuildwheel --output-dir wheelhouse
-      env:
-        CIBW_REPAIR_WHEEL_COMMAND_MACOS: "delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}"
-        CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=12.0 CMAKE_ARGS="-DSDTN_ENABLE_ARCH_FLAGS=OFF -DSDTN_DISABLE_OPENMP=ON"
+      - name: Build wheels
+        run: python -m cibuildwheel --output-dir wheelhouse
+        env:
+          CIBW_REPAIR_WHEEL_COMMAND_MACOS: "delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}"
+          CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=12.0 CMAKE_ARGS="-DSDTN_ENABLE_ARCH_FLAGS=OFF -DSDTN_DISABLE_OPENMP=ON"
 
-    - name: Verify clean directory
-      run: git diff --exit-code
-      shell: bash
+      - name: Verify clean directory
+        run: git diff --exit-code
+        shell: bash
 
-    - name: Upload wheels
-      uses: actions/upload-artifact@v7
-      with:
-        name: artifact-${{ matrix.os }}
-        path: wheelhouse/*.whl
-
+      - name: Upload wheels
+        uses: actions/upload-artifact@v7
+        with:
+          name: artifact-${{ matrix.os }}
+          path: wheelhouse/*.whl
 
   upload_all:
     name: Upload if release
@@ -74,8 +72,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/download-artifact@v8
-      with:
-        pattern: artifact-*
-        merge-multiple: true
-        path: dist
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: artifact-*
+          merge-multiple: true
+          path: dist

--- a/.github/workflows/numpy.yml
+++ b/.github/workflows/numpy.yml
@@ -14,19 +14,19 @@ jobs:
         numpy-version: ["numpy<2.0.0", "numpy>=2.0.0"]
 
     steps:
-    - uses: actions/checkout@v7
+      - uses: actions/checkout@v7
 
-    - uses: actions/setup-python@v7
-      with:
-        python-version: "3.12"
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
 
-    - name: Build and install
-      run: |
-        pip install pip --upgrade
-        pip install "${{ matrix.numpy-version }}"
-        pip install ".[test]" --verbose 
+      - name: Build and install
+        run: |
+          pip install pip --upgrade
+          pip install "${{ matrix.numpy-version }}"
+          pip install ".[test]" --verbose
 
-    - name: Test
-      run: |
-        cd tests
-        pytest -vv
+      - name: Test
+        run: |
+          cd tests
+          pytest -vv

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,21 +14,21 @@ jobs:
       fail-fast: false
       matrix:
         platform: [windows-latest, macos-latest, ubuntu-latest]
-        python-version: ["3.9", "3.14"]
+        python-version: ["3.10", "3.14"]
 
     steps:
-    - uses: actions/checkout@v7
+      - uses: actions/checkout@v7
 
-    - uses: actions/setup-python@v7
-      with:
-        python-version: ${{ matrix.python-version }}
+      - uses: actions/setup-python@v7
+        with:
+          python-version: ${{ matrix.python-version }}
 
-    - name: Build and install
-      run: |
-        pip install pip --upgrade
-        pip install ".[test]" --verbose 
+      - name: Build and install
+        run: |
+          pip install pip --upgrade
+          pip install ".[test]" --verbose
 
-    - name: Test
-      run: |
-        cd tests
-        pytest -vv
+      - name: Test
+        run: |
+          cd tests
+          pytest -vv

--- a/.github/workflows/test_all_python.yml
+++ b/.github/workflows/test_all_python.yml
@@ -12,21 +12,21 @@ jobs:
       fail-fast: false
       matrix:
         platform: [windows-latest, macos-latest, ubuntu-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
-    - uses: actions/checkout@v7
+      - uses: actions/checkout@v7
 
-    - uses: actions/setup-python@v7
-      with:
-        python-version: ${{ matrix.python-version }}
+      - uses: actions/setup-python@v7
+        with:
+          python-version: ${{ matrix.python-version }}
 
-    - name: Build and install
-      run: |
-        pip install pip --upgrade
-        pip install ".[test]" --verbose 
+      - name: Build and install
+        run: |
+          pip install pip --upgrade
+          pip install ".[test]" --verbose
 
-    - name: Test
-      run: |
-        cd tests
-        pytest -vv
+      - name: Test
+        run: |
+          cd tests
+          pytest -vv

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
   push:
     branches:
-     - main
+      - main
   release:
     types:
       - published
@@ -15,42 +15,42 @@ jobs:
     name: Build SDist
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7
-      with:
-        submodules: true
+      - uses: actions/checkout@v7
+        with:
+          submodules: true
 
-    - name: Build SDist
-      run: pipx run build --sdist
+      - name: Build SDist
+        run: pipx run build --sdist
 
-    - name: Normalize sdist filename
-      shell: bash
-      run: |
-        shopt -s nullglob
-        cd dist
+      - name: Normalize sdist filename
+        shell: bash
+        run: |
+          shopt -s nullglob
+          cd dist
 
-        for f in *.tar.gz; do
-          if [[ "$f" =~ ^([a-zA-Z0-9-]+)-([0-9].*)$ ]]; then
-            name_part="${BASH_REMATCH[1]}"
-            version_part="${BASH_REMATCH[2]}"
+          for f in *.tar.gz; do
+            if [[ "$f" =~ ^([a-zA-Z0-9-]+)-([0-9].*)$ ]]; then
+              name_part="${BASH_REMATCH[1]}"
+              version_part="${BASH_REMATCH[2]}"
 
-            normalized_name="${name_part//-/_}"
-            new_filename="${normalized_name}-${version_part}"
+              normalized_name="${name_part//-/_}"
+              new_filename="${normalized_name}-${version_part}"
 
-            if [[ "$f" != "$new_filename" ]]; then
-              echo "Renaming '$f' -> '$new_filename'"
-              mv "$f" "$new_filename"
+              if [[ "$f" != "$new_filename" ]]; then
+                echo "Renaming '$f' -> '$new_filename'"
+                mv "$f" "$new_filename"
+              fi
             fi
-          fi
-        done
-        ls -la .
+          done
+          ls -la .
 
-    - name: Check metadata
-      run: pipx run twine check dist/*
+      - name: Check metadata
+        run: pipx run twine check dist/*
 
-    - uses: actions/upload-artifact@v7
-      with:
-        name: artifact-sdist
-        path: dist/*.tar.gz
+      - uses: actions/upload-artifact@v7
+        with:
+          name: artifact-sdist
+          path: dist/*.tar.gz
 
   build_wheels:
     name: Wheels on ${{ matrix.os }}
@@ -61,63 +61,62 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
-    - uses: actions/checkout@v7
-      with:
-        submodules: true
+      - uses: actions/checkout@v7
+        with:
+          submodules: true
 
-    - uses: actions/setup-python@v7
-      with:
-        python-version: "3.11"
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.11"
 
-    - name: Cache OpenMP repo
-      if: matrix.os == 'macos-latest'
-      id: clone-openmp
-      uses: actions/cache@v6
-      with:
-        path: llvm-project
-        key: ${{ runner.os }}-openmp
+      - name: Cache OpenMP repo
+        if: matrix.os == 'macos-latest'
+        id: clone-openmp
+        uses: actions/cache@v6
+        with:
+          path: llvm-project
+          key: ${{ runner.os }}-openmp
 
-    - name: Clone OpenMP repo
-      if: matrix.os == 'macos-latest' && steps.clone-openmp.outputs.cache-hit != 'true'
-      run: |
-        git clone --depth 1 --branch llvmorg-19.1.1 https://github.com/llvm/llvm-project
+      - name: Clone OpenMP repo
+        if: matrix.os == 'macos-latest' && steps.clone-openmp.outputs.cache-hit != 'true'
+        run: |
+          git clone --depth 1 --branch llvmorg-19.1.1 https://github.com/llvm/llvm-project
 
+      - name: Build OpenMP
+        if: matrix.os == 'macos-latest'
+        shell: bash
+        run: |
+          PATH="$HOME/.local/:$PATH"
+          mv llvm-project/openmp ./openmp
+          mv llvm-project/cmake ./cmake
+          rm -rf llvm-project
+          mkdir openmp_build
+          cmake -S openmp -B openmp_build \
+              -DCMAKE_OSX_ARCHITECTURES="arm64" \
+              -DCMAKE_OSX_DEPLOYMENT_TARGET="12.0" \
+              -DCMAKE_BUILD_TYPE=Release \
+              -DCMAKE_C_COMPILER=clang \
+              -DCMAKE_CXX_COMPILER=clang++ \
+              -DCMAKE_INSTALL_PREFIX="$HOME/.local/libomp"
+          cmake --build openmp_build --target install --config Release
 
-    - name: Build OpenMP
-      if: matrix.os == 'macos-latest'
-      shell: bash
-      run: |
-        PATH="$HOME/.local/:$PATH"
-        mv llvm-project/openmp ./openmp
-        mv llvm-project/cmake ./cmake
-        rm -rf llvm-project
-        mkdir openmp_build
-        cmake -S openmp -B openmp_build \
-            -DCMAKE_OSX_ARCHITECTURES="arm64" \
-            -DCMAKE_OSX_DEPLOYMENT_TARGET="12.0" \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_C_COMPILER=clang \
-            -DCMAKE_CXX_COMPILER=clang++ \
-            -DCMAKE_INSTALL_PREFIX="$HOME/.local/libomp"
-        cmake --build openmp_build --target install --config Release
+      - uses: pypa/cibuildwheel@v4.2.0
+        env:
+          CIBW_ENVIRONMENT: CMAKE_ARGS="-DSDTN_ENABLE_ARCH_FLAGS=OFF -DSDTN_ENABLE_OPENMP=ON -DSDTN_DISABLE_OPENMP=OFF"
+          CIBW_TEST_COMMAND: pytest {project}/tests && python -c "from sparse_dot_topn import _has_openmp_support;assert _has_openmp_support"
+          # only build for arm; x86_64 wheels are build seperately
+          CIBW_ARCHS_MACOS: "arm64"
+          CIBW_ENVIRONMENT_MACOS: PATH="$HOME/.local/:$PATH" MACOSX_DEPLOYMENT_TARGET=12.0 DYLD_LIBRARY_PATH="$HOME/.local/libomp/lib" CMAKE_ARGS="-DSDTN_ENABLE_ARCH_FLAGS=OFF -DSDTN_VENDOR_OPENMP=ON -DSDTN_ENABLE_OPENMP=ON -DSDTN_DISABLE_OPENMP=OFF -DOpenMP_ROOT=$HOME/.local/libomp"
 
-    - uses: pypa/cibuildwheel@v4.2.0
-      env:
-        CIBW_ENVIRONMENT: CMAKE_ARGS="-DSDTN_ENABLE_ARCH_FLAGS=OFF -DSDTN_ENABLE_OPENMP=ON -DSDTN_DISABLE_OPENMP=OFF"
-        CIBW_TEST_COMMAND: pytest {project}/tests && python -c "from sparse_dot_topn import _has_openmp_support;assert _has_openmp_support"
-        # only build for arm; x86_64 wheels are build seperately
-        CIBW_ARCHS_MACOS: "arm64"
-        CIBW_ENVIRONMENT_MACOS: PATH="$HOME/.local/:$PATH" MACOSX_DEPLOYMENT_TARGET=12.0 DYLD_LIBRARY_PATH="$HOME/.local/libomp/lib" CMAKE_ARGS="-DSDTN_ENABLE_ARCH_FLAGS=OFF -DSDTN_VENDOR_OPENMP=ON -DSDTN_ENABLE_OPENMP=ON -DSDTN_DISABLE_OPENMP=OFF -DOpenMP_ROOT=$HOME/.local/libomp"
+      - name: Verify clean directory
+        run: git diff --exit-code
+        shell: bash
 
-    - name: Verify clean directory
-      run: git diff --exit-code
-      shell: bash
-
-    - name: Upload wheels
-      uses: actions/upload-artifact@v7
-      with:
-        name: artifact-${{ matrix.os }}
-        path: wheelhouse/*.whl
+      - name: Upload wheels
+        uses: actions/upload-artifact@v7
+        with:
+          name: artifact-${{ matrix.os }}
+          path: wheelhouse/*.whl
 
   build_macos_intel:
     name: MacOS x86_64 wheels
@@ -126,53 +125,53 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v7
-      with:
-        submodules: true
+      - uses: actions/checkout@v7
+        with:
+          submodules: true
 
-    - name: Cache OpenMP repo
-      id: clone-openmp
-      uses: actions/cache@v6
-      with:
-        path: llvm-project
-        key: ${{ runner.os }}-openmp
+      - name: Cache OpenMP repo
+        id: clone-openmp
+        uses: actions/cache@v6
+        with:
+          path: llvm-project
+          key: ${{ runner.os }}-openmp
 
-    - name: Clone OpenMP repo
-      if: steps.clone-openmp.outputs.cache-hit != 'true'
-      run: |
-        git clone --depth 1 --branch llvmorg-19.1.1 https://github.com/llvm/llvm-project
+      - name: Clone OpenMP repo
+        if: steps.clone-openmp.outputs.cache-hit != 'true'
+        run: |
+          git clone --depth 1 --branch llvmorg-19.1.1 https://github.com/llvm/llvm-project
 
-    - name: Build OpenMP
-      shell: bash
-      run: |
-        mv llvm-project/openmp ./openmp
-        mv llvm-project/cmake ./cmake
-        rm -rf llvm-project
-        mkdir openmp_build
-        cmake -S openmp -B openmp_build \
-            -DCMAKE_OSX_ARCHITECTURES="x86_64" \
-            -DCMAKE_OSX_DEPLOYMENT_TARGET="12.0" \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_C_COMPILER=clang \
-            -DCMAKE_CXX_COMPILER=clang++ \
-            -DCMAKE_INSTALL_PREFIX="/usr/local"
-        cmake --build openmp_build --target install --config Release
+      - name: Build OpenMP
+        shell: bash
+        run: |
+          mv llvm-project/openmp ./openmp
+          mv llvm-project/cmake ./cmake
+          rm -rf llvm-project
+          mkdir openmp_build
+          cmake -S openmp -B openmp_build \
+              -DCMAKE_OSX_ARCHITECTURES="x86_64" \
+              -DCMAKE_OSX_DEPLOYMENT_TARGET="12.0" \
+              -DCMAKE_BUILD_TYPE=Release \
+              -DCMAKE_C_COMPILER=clang \
+              -DCMAKE_CXX_COMPILER=clang++ \
+              -DCMAKE_INSTALL_PREFIX="/usr/local"
+          cmake --build openmp_build --target install --config Release
 
-    - uses: pypa/cibuildwheel@v4.2.0
-      env:
-        # only build for x86_64, arm wheels are build seperately
-        CIBW_ARCHS: "x86_64"
-        CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=12.0 CMAKE_ARGS="-DSDTN_ENABLE_ARCH_FLAGS=OFF -DSDTN_VENDOR_OPENMP=ON -DSDTN_ENABLE_OPENMP=ON -DSDTN_DISABLE_OPENMP=OFF -DOpenMP_ROOT=/usr/local"
+      - uses: pypa/cibuildwheel@v4.2.0
+        env:
+          # only build for x86_64, arm wheels are build seperately
+          CIBW_ARCHS: "x86_64"
+          CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=12.0 CMAKE_ARGS="-DSDTN_ENABLE_ARCH_FLAGS=OFF -DSDTN_VENDOR_OPENMP=ON -DSDTN_ENABLE_OPENMP=ON -DSDTN_DISABLE_OPENMP=OFF -DOpenMP_ROOT=/usr/local"
 
-    - name: Verify clean directory
-      run: git diff --exit-code
-      shell: bash
+      - name: Verify clean directory
+        run: git diff --exit-code
+        shell: bash
 
-    - name: Upload wheels
-      uses: actions/upload-artifact@v7
-      with:
-        name: artifact-macos-x86-64
-        path: wheelhouse/*.whl
+      - name: Upload wheels
+        uses: actions/upload-artifact@v7
+        with:
+          name: artifact-macos-x86-64
+          path: wheelhouse/*.whl
 
   publish-to-testpypi:
     name: Publish release on TestPyPi
@@ -181,22 +180,22 @@ jobs:
     if: github.repository_owner == 'ing-bank' && github.event_name == 'release' # prevent forks from running this step
     environment: testrelease
     permissions:
-      id-token: write  # IMPORTANT: mandatory for trusted publishing
+      id-token: write # IMPORTANT: mandatory for trusted publishing
 
     steps:
-    - uses: actions/setup-python@v7
-      with:
-        python-version: "3.11"
-    - uses: actions/download-artifact@v8
-      with:
-        pattern: artifact-*
-        merge-multiple: true
-        path: dist
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.11"
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: artifact-*
+          merge-multiple: true
+          path: dist
 
-    - uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        repository-url: https://test.pypi.org/legacy/
-        skip-existing: true
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
 
   pypi-publish:
     name: Publish release on PyPi
@@ -208,16 +207,16 @@ jobs:
       id-token: write
 
     steps:
-    - uses: actions/setup-python@v7
-      with:
-        python-version: "3.11"
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.11"
 
-    - uses: actions/download-artifact@v8
-      with:
-        pattern: artifact-*
-        merge-multiple: true
-        path: dist
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: artifact-*
+          merge-multiple: true
+          path: dist
 
-    - uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        skip-existing: true
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -3,7 +3,7 @@ name: Windows
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 23 * * 1'
+    - cron: "0 23 * * 1"
 
 jobs:
   tests:
@@ -12,21 +12,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
-    - uses: actions/checkout@v7
+      - uses: actions/checkout@v7
 
-    - uses: actions/setup-python@v7
-      with:
-        python-version: ${{ matrix.python-version }}
+      - uses: actions/setup-python@v7
+        with:
+          python-version: ${{ matrix.python-version }}
 
-    - name: Build and install
-      run: |
-        pip install pip --upgrade
-        pip install ".[test]" --verbose 
+      - name: Build and install
+        run: |
+          pip install pip --upgrade
+          pip install ".[test]" --verbose
 
-    - name: Test
-      run: |
-        cd tests
-        pytest -vv
+      - name: Test
+        run: |
+          cd tests
+          pytest -vv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,10 +4,10 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "sparse_dot_topn"
-version = "1.2.0"
+version = "1.2.1"
 description = "This package boosts a sparse matrix multiplication followed by selecting the top-n multiplication"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 authors = [
     {name = "ING Analytics Wholesale Banking", email = "wbaa@ing.com"},
 ]
@@ -57,7 +57,7 @@ SDTN_ENABLE_ARCH_FLAGS = true
 [tool.cibuildwheel]
 archs = ["auto64"]
 skip = ["*-win32", "*-manylinux_i686", "*-musllinux_x86_64"]
-build = ["cp39-*", "cp310-*", "cp311-*", "cp312-*", "cp313-*", "cp314-*"]
+build = ["cp310-*", "cp311-*", "cp312-*", "cp313-*", "cp314-*"]
 
 # make sure to build generic wheels
 environment = {CMAKE_ARGS="-DSDTN_ENABLE_ARCH_FLAGS=OFF -DSDTN_DISABLE_OPENMP=ON"}


### PR DESCRIPTION
Latest Nanobind version has dropped support for CPython 3.9 which was reflected in pipeline failures.
This PR resolves that issue by dropping support for 3.9 on our end as well.